### PR TITLE
Add Uniqueness Constraint to League name

### DIFF
--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -1,4 +1,4 @@
 class League < ActiveRecord::Base
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   validates :dh, inclusion: [true, false]
 end

--- a/db/migrate/20160319021924_add_name_index_to_league.rb
+++ b/db/migrate/20160319021924_add_name_index_to_league.rb
@@ -1,0 +1,5 @@
+class AddNameIndexToLeague < ActiveRecord::Migration
+  def change
+    add_index :leagues, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160312201127) do
+ActiveRecord::Schema.define(version: 20160319021924) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "leagues", force: :cascade do |t|
     t.string   "name",       null: false
@@ -20,5 +23,7 @@ ActiveRecord::Schema.define(version: 20160312201127) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_index "leagues", ["name"], name: "index_leagues_on_name", unique: true, using: :btree
 
 end

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe League do
-  it { should validate_presence_of(:name) }
-  it { should validate_inclusion_of(:dh).in_array([true, false]) }
+  describe "validations" do
+    subject { League.new(name: "American League", dh: true) }
+
+    it { should validate_presence_of(:name) }
+    it { should validate_uniqueness_of(:name) }
+    it { should validate_inclusion_of(:dh).in_array([true, false]) }
+  end
 end


### PR DESCRIPTION
It feels weird adding an index to a table that will only ever have 2 rows but we must ensure duplicate leagues are never created.
