### PR TITLE
Remove RSpec Boolean test to remove RSpec warning

### DIFF
--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -8,6 +8,5 @@ RSpec.describe League do
 
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:name) }
-    it { should validate_inclusion_of(:dh).in_array([true, false]) }
   end
 end


### PR DESCRIPTION
I looked at many possible solutions to this issue and the best solution (although not perfect) seems to be removing the test and leaving the model validation in place. I did like the RSpec-based reassurance that the model validation is in place, but these warnings will likely add up as the code base expands so I suppose its better not to set the precedent.

See [this Stack Overflow](http://stackoverflow.com/questions/5170008/rails-validating-inclusion-of-a-boolean-fails-tests) discussion for more details.
