### PR TITLE
Classify Pitchers as Starters and/or Relievers

### DIFF
--- a/app/models/pitcher.rb
+++ b/app/models/pitcher.rb
@@ -6,6 +6,7 @@ class Pitcher < ActiveRecord::Base
   validates :team, presence: true
   validates :first_name, presence: true
   validates :last_name, presence: true
+  validates :pitcher_type, presence: true
   validates :throws, presence: true
   validates :vs_lhb, presence: true
   validates :vs_rhb, presence: true
@@ -32,6 +33,13 @@ class Pitcher < ActiveRecord::Base
     "3" => "3",
     "4" => "4",
     "5" => "5"
+  }
+
+  enum pitcher_type: {
+    "SP" => "SP",
+    "RP" => "RP",
+    "SP/RP" => "SP/RP",
+    "RP/SP" => "RP/SP"
   }
 
   private

--- a/db/migrate/20160605223824_distinguish_starters_from_relievers.rb
+++ b/db/migrate/20160605223824_distinguish_starters_from_relievers.rb
@@ -1,0 +1,18 @@
+class DistinguishStartersFromRelievers < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE TYPE pitcher_type AS ENUM('SP', 'RP', 'SP/RP', 'RP/SP');
+    SQL
+ 
+    add_column :pitchers, :pitcher_type, :pitcher_type, null:false, default: "RP", after: :last_name 
+    change_column_default :pitchers, :pitcher_type, nil 
+  end
+
+  def down
+    remove_column :pitchers, :pitcher_type
+
+    execute <<-SQL
+      DROP TYPE pitcher_type;
+    SQL
+  end
+end

--- a/db/seeds/pitchers.rb
+++ b/db/seeds/pitchers.rb
@@ -4,6 +4,7 @@ Pitcher.create(
   team: team,
   first_name: "Rick",
   last_name: "Porcello",
+  pitcher_type: "SP",
   throws: "R",
   batting_rating: "1",
   wins: 9,

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -63,6 +63,18 @@ CREATE TYPE fielding_rating AS ENUM (
 
 
 --
+-- Name: pitcher_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE pitcher_type AS ENUM (
+    'SP',
+    'RP',
+    'SP/RP',
+    'RP/SP'
+);
+
+
+--
 -- Name: region; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -218,7 +230,8 @@ CREATE TABLE pitchers (
     image_small character varying,
     image_large character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    pitcher_type pitcher_type NOT NULL
 );
 
 
@@ -564,4 +577,6 @@ INSERT INTO schema_migrations (version) VALUES ('20160501202135');
 INSERT INTO schema_migrations (version) VALUES ('20160520022013');
 
 INSERT INTO schema_migrations (version) VALUES ('20160521220817');
+
+INSERT INTO schema_migrations (version) VALUES ('20160605223824');
 

--- a/spec/factories/pitchers.rb
+++ b/spec/factories/pitchers.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     team team
     first_name "Rick"
     last_name "Porcello"
+    pitcher_type "SP"
     throws "R"
     batting_rating "1"
     wins 9

--- a/spec/models/pitcher_spec.rb
+++ b/spec/models/pitcher_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Pitcher do
   it { should validate_presence_of(:team) }
   it { should validate_presence_of(:first_name) }
   it { should validate_presence_of(:last_name) }
+  it { should validate_presence_of(:pitcher_type) }
   it { should validate_presence_of(:throws) }
   it { should validate_presence_of(:vs_lhb) }
   it { should validate_presence_of(:vs_rhb) }
@@ -77,6 +78,7 @@ RSpec.describe Pitcher do
       team: red_sox,
       first_name: "Rick",
       last_name: "Porcello",
+      pitcher_type: "SP",
       throws: "R",
       batting_rating: "1",
       wins: 9,


### PR DESCRIPTION
Opted for an `enum` instead of a separate model.
